### PR TITLE
Per request of issue #1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
     ],
     "require": {
         "zircote/amqp": "1.0.0",
-        "zircote/uuid": "0.1.0"
+        "rhumsaa/uuid": "2.1.0"
+    },
+    "require-dev":{
+        "phpunit/phpunit": "3.7.19"
     },
     "autoload":{
         "psr-0":{

--- a/library/Rhubarb/Task.php
+++ b/library/Rhubarb/Task.php
@@ -21,6 +21,7 @@ namespace Rhubarb;
  * @category    Rhubarb
  * @subcategory Task
  */
+use Rhumsaa\Uuid\Uuid;
 
 /**
  * @package     Rhubarb
@@ -126,7 +127,7 @@ class Task
     public function __construct($name, $args = array(), Rhubarb $rhubarb, $id = null)
     {
         if(!$id){
-           $id = \Uuid\Uuid::generate();
+           $id = (string) Uuid::uuid1();
         }
         $this->setId($id)
             ->setArgs($args)


### PR DESCRIPTION
Changed the dependant Uuid library to a more common and feature full
library. If a task is not provided a Uuid upon creation it will generate
a version 1 Uuid for the task.

Addresses #1
