### PR TITLE
Fixed a bug that meant redis database numbers greater than zero (0) could not be used

### DIFF
--- a/library/Rhubarb/Connector/Predis.php
+++ b/library/Rhubarb/Connector/Predis.php
@@ -79,7 +79,7 @@ class Predis
             }
             if (isset($uri['path'])) {
                 $uri['database'] = trim($uri['path'], '/');
-                $options['connection']['database'] = isset($uri['databsae']) ? $uri['database'] : null;
+                $options['connection']['database'] = isset($uri['database']) ? $uri['database'] : null;
             }
             $options['connection']['host'] = $uri['host'];
             $options['connection']['port'] = isset($uri['port']) ? $uri['port'] : 6379;

--- a/tests/library/Rhubarb/PredisTest.php
+++ b/tests/library/Rhubarb/PredisTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace RhubarbTests;
 
+use Rhubarb\Connector\Predis as PredisConnector;
+
 /**
  * @license http://www.apache.org/licenses/LICENSE-2.0
  * Copyright [2012] [Robert Allen]
@@ -30,7 +32,7 @@ namespace RhubarbTests;
  */
 class PredisTest extends \PHPUnit_Framework_TestCase
 {
-    
+
     /**
      * @group job
      */
@@ -64,4 +66,24 @@ class PredisTest extends \PHPUnit_Framework_TestCase
 //        $this->assertEquals(2105, $res->get());
     }
 
+    public function testSetOptionsWhenNonZeroRedisDatabaseNumberIsSpecified()
+    {
+        $connector = new PredisConnector();
+        $connector->setOptions(
+            array('connection' => 'redis://127.0.0.1:6379/3')
+        );
+
+        $expectedOptions = array(
+            'connection' => array(
+                'database'=> 3,
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'login' => null,
+                'password' => null
+            ),
+            'options' => array()
+        );
+
+        $this->assertEquals($expectedOptions, $connector->getOptions());
+    }
 }


### PR DESCRIPTION
## For example

If you give the Predis connector a connection dsn similar to `redis://127.0.0.1:6379/3`, the expected behaviour is to use redis database 3, it doesn't. 

It always uses redis db 0.

The fix was to correct a small typo in the Rhubarb/Connector/Predis file.
