### PR TITLE
Address 2 items from issue #21, handling Connector/Amqp options.

### DIFF
--- a/library/Rhubarb/Connector/Amqp.php
+++ b/library/Rhubarb/Connector/Amqp.php
@@ -2,16 +2,16 @@
 namespace Rhubarb\Connector;
 
 /**
- * @package     
- * @category    
- * @subcategory 
+ * @package
+ * @category
+ * @subcategory
  */
 use AMQP\Connection;
 
 /**
- * @package     
- * @category    
- * @subcategory 
+ * @package
+ * @category
+ * @subcategory
  */
 class Amqp implements ConnectorInterface
 {
@@ -20,7 +20,7 @@ class Amqp implements ConnectorInterface
      * @var Connection
      */
     protected $connection;
-    
+
     /**
      * @var array
      */
@@ -67,8 +67,8 @@ class Amqp implements ConnectorInterface
             }
             unset($options['queue']);
         }
-        $merged = array('uri' => isset($options['connection']) ? $options['connection'] : $this->options['uri']);
-        $merge['options'] = array_merge($this->options['options'], (array) @$options['options']);
+        $merged = array('uri' => isset($options['uri']) ? $options['uri'] : $this->options['uri']);
+        $merged['options'] = array_merge($this->options['options'], (array) @$options['options']);
         $this->options = $merged;
         return $this;
     }


### PR DESCRIPTION
https://github.com/zircote/Rhubarb/issues/21

in Connector/Amqp::setOptions()...
* 'connection' option should be 'uri'
* capturing sub-options references wrong variable name $merge, where should be $merged